### PR TITLE
Bug: Fix Community Constructor

### DIFF
--- a/src/community.cpp
+++ b/src/community.cpp
@@ -5,8 +5,18 @@ Community::Community()
   : name(""), people(map<string,Person>()) {
 }
 
-Community::Community(string _name, map<string,Person> _people)
-  : name(_name), people(_people) {
+bool valid_comm_name(string _name) {
+  return (_name != "" && _name.length() <= 128 && !isdigit(_name[0]) && str_isalnum(_name));
+}
+
+Community::Community(string _name, map<string,Person> _people) {
+    if(valid_comm_name(_name)) {
+      set_name(_name);
+      people = _people;
+    } else {
+      name = "";
+      people = map<string,Person>();
+    }
 }
 
 string Community::get_name() {
@@ -14,7 +24,7 @@ string Community::get_name() {
 }
 
 bool Community::set_name(string _name) {
-  if(_name != "" && _name.length() <= 128 && !isdigit(_name[0]) && str_isalnum(_name)) {
+  if(valid_comm_name(_name)) {
     name = _name;
     return true;
   }

--- a/test/test_community.cpp
+++ b/test/test_community.cpp
@@ -6,6 +6,8 @@
 class test_community: public ::testing::Test {
 protected:
 	Community community;
+	Community* illegal = new Community("!Illegal", map<string,Person>
+		{{"alpha1", Person("alpha1", "Ash", "Ketchum", 2, 18, "Pikachu")}});
 	Community* loaded = new Community("Summerbrooke", map<string,Person>
 		{{"alpha1", Person("alpha1", "Ash", "Ketchum", 2, 18, "Pikachu")}});
 	Person* loaded_person = new Person("beta2", "Officer", "Jenny", 1, 20, "Chansey");
@@ -16,6 +18,10 @@ protected:
 TEST_F(test_community, test_constructors) {
 	EXPECT_EQ(community.get_name(), "");
 	EXPECT_EQ(community.get_all_usernames().empty(), true);
+
+	EXPECT_EQ(illegal -> get_name() == "!Illegal", false);
+	EXPECT_EQ(illegal -> get_name(), "");
+	EXPECT_EQ(illegal -> get_all_usernames().empty(), true);
 
 	EXPECT_EQ(loaded -> get_name(), "Summerbrooke");
 	EXPECT_EQ(loaded -> get_all_usernames().empty(), false);


### PR DESCRIPTION
Fix Community constructor to check for valid name before setting private variables - otherwise NULL Community object is returned.